### PR TITLE
Compile Regex only once

### DIFF
--- a/Parser.hs
+++ b/Parser.hs
@@ -3,13 +3,14 @@ module Parser (Command(..), parseSed) where
 import Data.Char (isAlpha)
 import Text.Parsec
 import Text.Parsec.String
+import Text.Regex
 
 data Command = Print
              | Delete
              | Next
              | Hold
-             | Substitute String String String
-             deriving Show
+             | Substitute Regex String String
+             --deriving Show
 
 delims :: String
 delims = "!@#$%^&*-_=+'\";:,./?|"
@@ -42,4 +43,4 @@ parseSubstitute = do
     replace <- many $ satisfy (/= delim)
     char delim
     flags <- many $ satisfy isAlpha
-    return (Substitute pattern replace flags)
+    return $ Substitute (mkRegex pattern) replace flags

--- a/Sed.hs
+++ b/Sed.hs
@@ -50,9 +50,10 @@ execute Next = do
                             zipper = Z.delete $ zipper s,
                             patternSpace = Z.cursor $ zipper s }
 execute Hold = modify $ \s -> s { holdSpace = patternSpace s }
-execute (Substitute p r _) = modify $ \s ->
-    let regex = TR.subRegex (TR.mkRegex p) (T.unpack $ patternSpace s) r
-    in s { patternSpace = T.pack regex }
+execute (Substitute regexp repl _) = modify $ \s ->
+    let ps   = T.unpack . patternSpace $ s
+        subs = TR.subRegex regexp ps repl
+    in s { patternSpace = T.pack subs }
 
 -- (<+>) :: T.Text -> T.Text -> T.Text
 -- a <+> b = a `T.append` T.cons '\n' b


### PR DESCRIPTION
Regular expressions in `Substitute` commands are compiled all over whenever one such command is executed. In order to avoid redundant compilation, this change moves the corresponding parts to the parsing site.
