### PR TITLE
Laziness

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -7,7 +7,7 @@ import Data.List (intercalate)
 import System.Console.GetOpt
 import System.Environment (getArgs)
 import System.Exit
-import qualified Data.Text.IO as TIO
+import qualified Data.Text.Lazy.IO as TIO
 
 data Flag = Help
           | Quiet

--- a/src/Sed.hs
+++ b/src/Sed.hs
@@ -31,13 +31,14 @@ runCommands cs = do
         ss <- get
         return . T.unlines . Z.toList $ zipper ss
     else do
-        -- To support laziness, we should grab the output that we
-        -- have so far and make it available as a lazy Text block.
+        execute Next
+        modify $ \s -> s { skip = False }
+        -- To support laziness, we should, before we recurse, grab
+        -- the output that we have so far and make it available as
+        -- a lazy Text block.
         ssWithOutput <- get
         let (Z.Zip outputSoFar remainder) = zipper ssWithOutput
         modify $ \s -> s { zipper = Z.Zip [] remainder }
-        execute Next
-        modify $ \s -> s { skip = False }
         rest <- runCommands cs
         return $ T.concat [T.unlines outputSoFar, rest]
 

--- a/src/Sed.hs
+++ b/src/Sed.hs
@@ -27,10 +27,8 @@ runCommands cs = do
     -- To support laziness, we should grab the output that we
     -- have so far and make it available as a lazy Text block.
     ssWithOutput <- get
-    let (Z.Zip ls rs) = zipper ssWithOutput
-        outputSoFar = T.unlines $ Z.toList $ Z.Zip ls []
-        remainder   = Z.Zip [] rs
-    modify $ \s -> s { zipper = remainder }
+    let (Z.Zip outputSoFar remainder) = zipper ssWithOutput
+    modify $ \s -> s { zipper = Z.Zip [] remainder }
     ss <- get
     if Z.endp $ zipper ss
     then do
@@ -41,7 +39,7 @@ runCommands cs = do
         execute Next
         modify $ \s -> s { skip = False }
         rest <- runCommands cs
-        return $ T.concat [outputSoFar, rest]
+        return $ T.concat [T.unlines outputSoFar, rest]
 
 runCommand :: Command -> State SedState ()
 runCommand c = gets skip >>= \skp -> unless skp (execute c)

--- a/src/Sed.hs
+++ b/src/Sed.hs
@@ -3,7 +3,7 @@ module Sed (sed) where
 import Parser
 
 import Control.Monad.State
-import qualified Data.Text as T
+import qualified Data.Text.Lazy as T
 import qualified Data.List.Zipper as Z
 import qualified Text.Regex as TR
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,7 +1,7 @@
 module Main (main) where
 
 import Sed
-import qualified Data.Text as T
+import qualified Data.Text.Lazy as T
 
 import Control.Monad
 import Data.List

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,8 +25,23 @@ sedCase n txt cs = do
     gnuSed <- readProcess "sed" cmd txt
     return $ testCase (show cs) $ sed n cs (T.pack txt) @?= T.pack gnuSed
 
+-- Here we create an input consisting of ten valid lines plus one
+-- (final) line that will cause an error when evaluated.  We  use
+-- this input to make sure that the sed function does not consume
+-- any more input then it needs  to  produce the amount of output
+-- that we ask it for. This test uses the sed function  to  simu-
+-- late  running  `yes | sed -n 'p' | head 1` at the command line
+-- to verify that it termintaes.
+lazyCase :: IO Test
+lazyCase = do
+    let input  = replicate 10 "y" ++ [error "Non-Laziness Detected"]
+    let result = sed True "p" (T.unlines $ map T.pack $ input)
+    mapM_ print $ map T.unpack $ take 1 $ T.lines $ result
+    return $ testCase "lazyCase" (assertBool "" True)
+
 main :: IO ()
 main = do
     loud <- mapM (sedCase False text) tests
     quiet <- mapM (sedCase True text) tests
-    defaultMain [testGroup "sed" loud, testGroup "sed -n" quiet]
+    lazy <- lazyCase
+    defaultMain [testGroup "sed" loud, testGroup "sed -n" quiet, lazy]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -31,7 +31,7 @@ sedCase n txt cs = do
 -- any more input then it needs  to  produce the amount of output
 -- that we ask it for. This test uses the sed function  to  simu-
 -- late  running  `yes | sed -n 'p' | head 1` at the command line
--- to verify that it termintaes.
+-- to verify that it terminates.
 lazyCase :: IO Test
 lazyCase = do
     let input  = replicate 10 "y" ++ [error "Non-Laziness Detected"]


### PR DESCRIPTION
Hi there,
I noticed that your implementation of sed is not lazy in the sense that this will never terminate:

$ yes | sed '' | head

as it normally does.  I made some minor changes to fix this that are in these pull request (basically changing Text --> Text.Lazy and tweaking how the runCommands function accumulates output).  Also, I added a test for laziness.  Then, once the program can operate on an infinite input, another test that can be done is to make sure that it doesn't get slower the more input is consumed, so e.g.:

$ yes | nl | sed ''

should run through the numbers at a constant rate, no matter how much is consumed; doing that led to dd74d1e which gives sed this behavior.

Although I'm submitting a pull request, I thought that maybe instead of taking my pull request you might prefer to make another youtube video where you work through it (or a better approach that you might think of) so that viewers can watch (I like your videos and hope that you film more).
David